### PR TITLE
Update Tasmota template w/ ButtonDebounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ General troubleshooting ideas applicable to all products are located in the [Com
 ## Recommended Tasmota Template
 
 ```
-{"NAME":"KAUF Plug","GPIO":[576,0,320,0,224,2720,0,0,2624,32,2656,0,0,0],"FLAG":0,"BASE":18, "CMND":"SwitchDebounce 100"}
+{"NAME":"KAUF Plug","GPIO":[576,0,320,0,224,2720,0,0,2624,32,2656,0,0,0],"FLAG":0,"BASE":18, "CMND":"SwitchDebounce 100", "CMND":"ButtonDebounce 100"}
 ```
 
 ## Links


### PR DESCRIPTION
ButtonDebounce defaults to 50 on tasmota, which has a tendency to false trigger the button and cause the light to randomly go on/off.  This sets the ButtonDebounce as well as the SwitchDebounce which seems to alleviate the issue for me.