### PR TITLE
Enable Extension of OTA Configurations

### DIFF
--- a/config/kauf-plug-lite.yaml
+++ b/config/kauf-plug-lite.yaml
@@ -161,9 +161,11 @@ api:
 # https://esphome.io/components/ota.html
 ota:
   - platform: web_server
+    id: kauf_web_server_ota
     on_error:
       - button.press: restart_button
   - platform: esphome
+    id: kauf_esphome_ota
     on_error:
       - button.press: restart_button
 

--- a/config/kauf-plug-lite.yaml
+++ b/config/kauf-plug-lite.yaml
@@ -15,7 +15,7 @@ substitutions:
 
   # https://esphome.io/components/esphome.html#esphome-creators-project
   project_name: Kauf.PLF10
-  project_ver_num: "2.107"
+  project_ver_num: "2.117"
   project_ver_let: l
 
   # https://esphome.io/components/switch/gpio.html?highlight=restore_mode

--- a/config/kauf-plug-minimal.yaml
+++ b/config/kauf-plug-minimal.yaml
@@ -83,7 +83,9 @@ logger:           # https://esphome.io/components/logger.html
 api:              # https://esphome.io/components/api.html
 ota:              # https://esphome.io/components/ota.html
   - platform: esphome
+    id: kauf_esphome_ota
   - platform: web_server
+    id: kauf_web_server_ota
 safe_mode:
 
 

--- a/config/kauf-plug-minimal.yaml
+++ b/config/kauf-plug-minimal.yaml
@@ -50,7 +50,7 @@ esphome:
   # https://esphome.io/components/esphome.html#esphome-creators-project
   project:
     name: "Kauf.PLF10"
-    version: "2.107(m)"
+    version: "2.117(m)"
 
   min_version: 2026.1.0
 

--- a/kauf-plug.yaml
+++ b/kauf-plug.yaml
@@ -15,7 +15,7 @@ substitutions:
 
   # https://esphome.io/components/esphome.html#esphome-creators-project
   project_name: Kauf.PLF10
-  project_ver_num: "2.116"
+  project_ver_num: "2.117"
   project_ver_let: y
 
   # https://esphome.io/components/switch/gpio.html?highlight=restore_mode

--- a/kauf-plug.yaml
+++ b/kauf-plug.yaml
@@ -92,7 +92,7 @@ substitutions:
   # threshold for in_use sensor
   sub_threshold: "3"
 
-  # KAUF deprecated substitutions  
+  # KAUF deprecated substitutions
   sub_reboot_timeout:    "__KAUF_DEPRECATED_SENTINEL__"  # deprecated; see https://github.com/KaufHA/common/blob/main/DEPRECATED_SUBSTITUTIONS.md#sub_reboot_timeout
   default_button_config: "__KAUF_DEPRECATED_SENTINEL__"  # deprecated; see https://github.com/KaufHA/common/blob/main/DEPRECATED_SUBSTITUTIONS.md#default_button_config
   disable_webserver:     "__KAUF_DEPRECATED_SENTINEL__"  # deprecated; see https://github.com/KaufHA/common/blob/main/DEPRECATED_SUBSTITUTIONS.md#disable_webserver
@@ -183,9 +183,11 @@ api:
 # https://esphome.io/components/ota.html
 ota:
   - platform: web_server
+    id: kauf_web_server_ota
     on_error:
       - button.press: restart_button
   - platform: esphome
+    id: kauf_esphome_ota
     on_error:
       - button.press: restart_button
 


### PR DESCRIPTION

I have a custom configuration that adds a password to the `esphome` OTA platform inherited from the imported package:

```yaml
ota:
- platform: esphome
  password: !secret garage_refrigerator_ota_password
```

When I validate or compile this configuration I'm presented with a warning:

```
WARNING Found and merged multiple configurations for ota platform esphome port(s) [8266]
```

A [recent change in 2026.3.0](https://github.com/esphome/esphome/pull/14682) highlighted for me that there's a `!extend` syntax that is made for this purpose.  Unfortunately it does require upstream packages to add an `id` field to anything that needs to be extended.

This change adds the `id` field to every OTA configuration so that downstream users can create the following configuration that eliminates the warning:

```yaml
ota:
- id: !extend kauf_esphome_ota
  platform: esphome
  password: !secret garage_refrigerator_ota_password
```